### PR TITLE
Added parameter failOnRtsError

### DIFF
--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -114,6 +114,8 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
    private String clazzFolders;
    private String testClazzFolders;
 
+   private boolean failOnRtsError = false;
+
    @DataBoundConstructor
    public MeasureVersionBuilder() {
    }
@@ -171,6 +173,12 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
          run.setResult(Result.FAILURE);
          return;
       }
+
+      if (failOnRtsError && tests.isRtsError()) {
+         run.setResult(Result.FAILURE);
+         return;
+      }
+
       processManager.visualizeRTSResults(run, tests.getLogSummary());
 
       if (tests.getResult().getTests().size() > 0) {
@@ -234,6 +242,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       listener.getLogger().println("Excludes: " + excludes);
       listener.getLogger().println("Strategy: " + measurementMode + " Source Instrumentation: " + useSourceInstrumentation + " Aggregation: " + useAggregation);
       listener.getLogger().println("Create default constructor: " + createDefaultConstructor);
+      listener.getLogger().println("Fail on error in RTS: " + failOnRtsError);
    }
 
    private String getJobName(final Run<?, ?> run) {
@@ -711,6 +720,15 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       this.testClazzFolders = testClazzFolders;
    }
    
+   public boolean isFailOnRtsError() {
+      return failOnRtsError;
+   }
+
+   @DataBoundSetter
+   public void setFailOnRtsError(boolean failOnRtsError) {
+      this.failOnRtsError = failOnRtsError;
+   }
+
    public long getKiekerQueueSize() {
       return kiekerQueueSize;
    }

--- a/src/main/java/de/dagere/peass/ci/logs/rts/AggregatedRTSResult.java
+++ b/src/main/java/de/dagere/peass/ci/logs/rts/AggregatedRTSResult.java
@@ -5,6 +5,7 @@ import de.dagere.peass.ci.RTSResult;
 public class AggregatedRTSResult {
    private final RTSLogSummary logSummary;
    private final RTSResult result;
+   private boolean rtsError = false;
 
    public AggregatedRTSResult(final RTSLogSummary logSummary, final RTSResult result) {
       this.logSummary = logSummary;
@@ -17,6 +18,14 @@ public class AggregatedRTSResult {
 
    public RTSResult getResult() {
       return result;
+   }
+
+   public boolean isRtsError() {
+      return rtsError;
+   }
+
+   public void setRtsError(final boolean rtsError) {
+      this.rtsError = rtsError;
    }
 
 }

--- a/src/main/java/de/dagere/peass/ci/process/LocalPeassProcessManager.java
+++ b/src/main/java/de/dagere/peass/ci/process/LocalPeassProcessManager.java
@@ -83,14 +83,28 @@ public class LocalPeassProcessManager {
       if (peassConfig.isDisplayRTSLogs()) {
          RTSInfos infos = RTSInfos.readInfosFromFolders(results, peassConfig);
          RTSLogSummary summary = logActionCreator.createRTSActions(infos);
-         return new AggregatedRTSResult(summary, result);
+         AggregatedRTSResult aggregatedRTSResult = new AggregatedRTSResult(summary, result);
+         checkAndSetRtsError(aggregatedRTSResult);
+         return aggregatedRTSResult;
       }
       if (result != null && result.getTests() != null) {
-         return new AggregatedRTSResult(null, result);
+         AggregatedRTSResult aggregatedRTSResult = new AggregatedRTSResult(null, result);
+         checkAndSetRtsError(aggregatedRTSResult);
+         return aggregatedRTSResult;
       } else {
          return null;
       }
 
+   }
+
+   private void checkAndSetRtsError(final AggregatedRTSResult aggregatedRTSResult) {
+      final RTSLogSummary rtsLogSummary = aggregatedRTSResult.getLogSummary();
+      final boolean errorInCurrentVersion = rtsLogSummary.isErrorInCurrentVersionOccured();
+      final boolean errorInPredecessorVersion = rtsLogSummary.isErrorInPredecessorVersionOccured();
+      if (errorInCurrentVersion || errorInPredecessorVersion) {
+         LOG.error("RTS-logs indicated an error! current Version: {}, previous Version: {}", errorInCurrentVersion, errorInPredecessorVersion);
+         aggregatedRTSResult.setRtsError(true);
+      }
    }
 
    public boolean measure(final Set<TestCase> tests) throws IOException, InterruptedException {

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.jelly
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.jelly
@@ -119,6 +119,9 @@
     <f:entry title="${%testClazzFolders}" field="testClazzFolders" description="${%testClazzFolders}">
       <f:textbox default="src/test/java:src/test" />
     </f:entry>
+    <f:entry title="${%failOnRtsError}" field="failOnRtsError" description="${%failOnRtsErrorDescr}">
+      <f:checkbox default="false" />
+    </f:entry>
     <f:entry title="${%kiekerWaitTime}" field="kiekerWaitTime" description="${%kiekerWaitTimeDescr}">
       <f:textbox default="10" />
     </f:entry>

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.properties
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.properties
@@ -110,6 +110,9 @@ clazzFoldersDescr=Specified where the build tool searches for clazzes (by defaul
 testClazzFolders=Spezify build tool test class folders
 testClazzFoldersDescr=Specified where the build tool searches for test clazzes (by default: src/test/java:src/test - the first existing folder will be used for each module)
 
+failOnRtsError=Fail build, if RTS-logs indicate error
+failOnRtsErrorDescr=If RTS-logs indicate an error for any test in current or previous version, the whole build fails
+
 kiekerWaitTime=Kieker Wait Time
 kiekerWaitTimeDescr=Time that KoPeMe should wait until Kieker writing is finshed in seconds (default: 10)
 

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config_de.properties
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config_de.properties
@@ -109,6 +109,9 @@ clazzFoldersDescr=Spezifiziert wo nach Klassen gesucht wird (default: src/main/j
 testClazzFolders=Spezifiziert die Buildtool-Testklassenordner
 testClazzFoldersDescr=Spezifiziert wo nach Testklassen gesucht wird (default: src/test/java:src/test - der erste existierende Ordner wird im jeweiligen Modul genutzt)
 
+failOnRtsError=Build scheitern lassen, wenn RTS-Logs Fehler zeigen
+failOnRtsErrorDescr=Zeigen die RTS-Logs für irgendeinen Test in aktueller oder Vorgängerversion einen Fehler, schlägt der gesamte Build fehl
+
 kiekerWaitTime=Kieker Wait Time
 kiekerWaitTimeDescr=Zeit, die KoPeMe wartet, bis das Schreiben der Kieker-Record-Queue beendet ist (default: 10)
 


### PR DESCRIPTION
For nightly-builds it can be helpful, to let a build fail if any errors occur in regression test selection. If your build is error-free, by setting failOnRtsError you will now notice, if any new changes cause new errors in RTS.

