### PR TITLE
Localize values

### DIFF
--- a/src/main/java/de/dagere/peass/ci/MeasureVersionAction.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionAction.java
@@ -1,7 +1,9 @@
 package de.dagere.peass.ci;
 
+import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -128,8 +130,11 @@ public class MeasureVersionAction extends VisibleAction {
       return name.substring(prefix.length());
    }
 
-   public double round(final double value) {
-      return Math.round(value * 10000) / 10000d;
+   public String localizeAndRound(final double value) {
+      final NumberFormat numberFormat = NumberFormat.getInstance(Locale.getDefault(Locale.Category.FORMAT));
+      numberFormat.setMinimumFractionDigits(0);
+      numberFormat.setMaximumFractionDigits(4);
+      return (numberFormat.format(value));
    }
 
    public double getMeanOfValues(final double[] values) {

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionAction/index.jelly
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionAction/index.jelly
@@ -83,7 +83,7 @@
         (= ${(1-it.config.statisticsConfig.type1error)*100}% significance level) and
         <b>${it.config.vms}</b>
         VMs, the absolute t-value needs to be above the critical t-value
-        <b>${it.round(it.getCriticalTValue())}</b>
+        <b>${it.localizeAndRound(it.getCriticalTValue())}</b>
         to indicate a performance change.
         <br />
         Selected values are available
@@ -111,11 +111,11 @@
                   <j:set var="oldTime" value="${methodChange.oldTime}" />
                   <j:set var="factor" value="${it.getFactorByMean(oldTime)}" />
                   <j:set var="unit" value="${it.getUnitByFactor(factor)}" />
-                  <td>${it.round(oldTime / factor)} ${unit}</td>
+                  <td>${it.localizeAndRound(oldTime / factor)} ${unit}</td>
                 </tr>
                 <tr>
                   <td>Change</td>
-                  <td><span>${methodChange.changePercent} %</span><br /><span>t = ${it.round(methodChange.tvalue)}</span></td>
+                  <td><span>${methodChange.changePercent} %</span><br /><span>t = ${it.localizeAndRound(methodChange.tvalue)}</span></td>
                 </tr>
               </table>
             </div>

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionAction/measurements.jelly
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionAction/measurements.jelly
@@ -54,43 +54,43 @@
           <tr>
             <td>${%mean}<br />${%measured}</td>
             <td>
-              ${it.round(currentStatistic.getMeanOld() / factorOld)} ${unit}
+              ${it.localizeAndRound(currentStatistic.getMeanOld() / factorOld)} ${unit}
             </td>
             <td>
-              ${it.round(currentStatistic.getMeanCurrent() / factorOld)} ${unit}
+              ${it.localizeAndRound(currentStatistic.getMeanCurrent() / factorOld)} ${unit}
             </td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.getMeanOld()*currentRepetitions/factorOld)} ${unit}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.getMeanCurrent()*currentRepetitions/factorOld)} ${unit}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.getMeanOld()*currentRepetitions/factorOld)} ${unit}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.getMeanCurrent()*currentRepetitions/factorOld)} ${unit}</td>
           </tr>
           <tr>
             <td>${%standardDeviation}<br />${%measured}</td>
             <td>
-              ${it.round(currentStatistic.deviationOld / factorOld)}
+              ${it.localizeAndRound(currentStatistic.deviationOld / factorOld)}
             </td>
             <td>
-              ${it.round(currentStatistic.deviationCurrent / factorOld)}
+              ${it.localizeAndRound(currentStatistic.deviationCurrent / factorOld)}
             </td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.deviationOld*currentRepetitions/factorOld)}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.deviationCurrent*currentRepetitions/factorOld)}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.deviationOld*currentRepetitions/factorOld)}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.deviationCurrent*currentRepetitions/factorOld)}</td>
           </tr>
           <tr>
             <td>${%mean}<br />${%perRepetition}</td>
-            <td>${it.round(currentStatistic.getMeanOld() / currentRepetitions / factorOld)} ${unit}</td>
-            <td>${it.round(currentStatistic.getMeanCurrent() / currentRepetitions / factorOld)} ${unit}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.getMeanOld()/factorOld)} ${unit}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.getMeanCurrent()/factorOld)} ${unit}</td>
+            <td>${it.localizeAndRound(currentStatistic.getMeanOld() / currentRepetitions / factorOld)} ${unit}</td>
+            <td>${it.localizeAndRound(currentStatistic.getMeanCurrent() / currentRepetitions / factorOld)} ${unit}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.getMeanOld()/factorOld)} ${unit}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.getMeanCurrent()/factorOld)} ${unit}</td>
           </tr>
           <tr>
             <td>${%standardDeviation}<br />${%perRepetition}</td>
-            <td>${it.round(currentStatistic.deviationOld / currentRepetitions / factorOld)}</td>
-            <td>${it.round(currentStatistic.deviationCurrent / currentRepetitions / factorOld)}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.deviationOld/factorOld)}</td>
-            <td class="fullMeasurement" style="display: none">${it.round(noWarmupStatistic.deviationCurrent/factorOld)}</td>
+            <td>${it.localizeAndRound(currentStatistic.deviationOld / currentRepetitions / factorOld)}</td>
+            <td>${it.localizeAndRound(currentStatistic.deviationCurrent / currentRepetitions / factorOld)}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.deviationOld/factorOld)}</td>
+            <td class="fullMeasurement" style="display: none">${it.localizeAndRound(noWarmupStatistic.deviationCurrent/factorOld)}</td>
           </tr>
           <tr>
             <td>T-Wert</td>
             <td colspan="2">
-              ${it.round(currentStatistic.tvalue)}
+              ${it.localizeAndRound(currentStatistic.tvalue)}
               <span>(</span>
               <j:if test="${it.abs(currentStatistic.tvalue) &gt; it.getCriticalTValue()}">${%significantChange} ${AMP} </j:if>
               <j:if test="${it.abs(currentStatistic.tvalue) &lt; it.getCriticalTValue()}">${%noSignificantChange} ${AMP} </j:if>
@@ -99,7 +99,7 @@
               </a>
               <span>)</span>
             </td>
-            <td class="fullMeasurement" colspan="2" style="display: none">${it.round(noWarmupStatistic.tvalue)}</td>
+            <td class="fullMeasurement" colspan="2" style="display: none">${it.localizeAndRound(noWarmupStatistic.tvalue)}</td>
           </tr>
           <div id="dialogTValue" title="${%helpTValueTitle}">
             ${%helpTValueStart}
@@ -108,7 +108,7 @@
             ${%helpTValueSignificance}
             <b>${it.config.vms}</b> VMs (Degrees of Freedom: <b>${it.getDegreesOfFreedom()}</b>)
             ${%helpTValueMiddle}
-            <b>${it.round(it.getCriticalTValue())}</b>
+            <b>${it.localizeAndRound(it.getCriticalTValue())}</b>
             ${%helpTValueEnd}
           </div>
           <script>


### PR DESCRIPTION
Display measurement values as localized strings, so e.g. 1.2 is displayed as 1,2 if language is german.
