### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,9 +47,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.0.0
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0

--- a/.github/workflows/mavenDevelop.yml
+++ b/.github/workflows/mavenDevelop.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         ref: develop
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.0.0
       with:
         java-version: ${{ matrix.java }}
     - name: Cache Maven packages

--- a/.github/workflows/mavenDevelopForPR.yml
+++ b/.github/workflows/mavenDevelopForPR.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.0.0
       with:
         java-version: ${{ matrix.java }}
     - name: Cache Maven packages

--- a/.github/workflows/mavenMain.yml
+++ b/.github/workflows/mavenMain.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.0.0
       with:
         java-version: ${{ matrix.java }}
     - name: Cache Maven packages


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage
