### PR TITLE
Catch Peass Analysis error in case, no changes.json exists.

### DIFF
--- a/src/main/java/de/dagere/peass/ci/peassAnalysis/PeassAnalysisBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/peassAnalysis/PeassAnalysisBuilder.java
@@ -42,9 +42,16 @@ public class PeassAnalysisBuilder extends Builder implements SimpleBuildStep, Se
       ResultsFolders resultsFolders = new ResultsFolders(localWorkspace, projectName);
       
       StaticTestSelection selection = Constants.OBJECTMAPPER.readValue(resultsFolders.getStaticTestSelectionFile(), StaticTestSelection.class);
-      ProjectChanges changes = Constants.OBJECTMAPPER.readValue(resultsFolders.getChangeFile(), ProjectChanges.class);
       
-      PeassAnalysisAction action = new PeassAnalysisAction(IdHelper.getId(), selection, changes);
+      ProjectChanges projectChanges = new ProjectChanges();
+      final File changeFile = resultsFolders.getChangeFile();
+      if (changeFile.exists()) {
+         projectChanges = Constants.OBJECTMAPPER.readValue(resultsFolders.getChangeFile(), ProjectChanges.class);
+      } else {
+         listener.getLogger().println(changeFile.getAbsolutePath() + " does not exist! If there are no Trace-based Selected Tests, that's ok.");
+      }
+
+      PeassAnalysisAction action = new PeassAnalysisAction(IdHelper.getId(), selection, projectChanges);
       run.addAction(action);
    }
    

--- a/src/main/java/de/dagere/peass/ci/peassAnalysis/PeassAnalysisBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/peassAnalysis/PeassAnalysisBuilder.java
@@ -22,7 +22,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
-import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildStep;
 
 public class PeassAnalysisBuilder extends Builder implements SimpleBuildStep, Serializable {


### PR DESCRIPTION
If there are no changes or no testcase calls them, no .../peass-data/changes.json is created. This caused an error with Peass Analysis looking for it.