### PR TITLE
Avoid setting buildstate to "unstable" if parameterizedTests exist

### DIFF
--- a/a12a0b7f4c162794fca0e7e3fcc6ea3b3a2cbc2b/pure_kopeme/de.dagere.peass.ExampleTest_test(JUNIT_PARAMETERIZED-0).json
+++ b/a12a0b7f4c162794fca0e7e3fcc6ea3b3a2cbc2b/pure_kopeme/de.dagere.peass.ExampleTest_test(JUNIT_PARAMETERIZED-0).json
@@ -1,0 +1,233 @@
+var treeData = {};
+
+var kopemeData = [
+{
+  "call" : "overall",
+  "kiekerPattern" : "public overall.overall()",
+  "otherKiekerPattern" : "public overall.overall()",
+  "name" : null,
+  "key" : "overall.overall_",
+  "otherKey" : "overall.overall_",
+  "parent" : null,
+  "color" : null,
+  "statistic" : {
+    "meanOld" : 1604840.9583333333,
+    "meanCurrent" : 1.0647330645833332E7,
+    "deviationOld" : 581631.1769296796,
+    "deviationCurrent" : 1.0967411885672105E7,
+    "vms" : 4,
+    "callsOld" : 24,
+    "calls" : 24,
+    "tvalue" : -1.6466602513854658
+  },
+  "hasSourceChange" : false,
+  "state" : null,
+  "inVMDeviationPredecessor" : 0.0,
+  "inVMDeviation" : 0.0,
+  "ess" : 0,
+  "vmValues" : {
+    "values" : {
+      "0" : [ {
+        "mean" : 1228489.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1228489.0,
+        "min" : 1228489.0,
+        "sum" : 2456978.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1065200.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1065200.0,
+        "min" : 1065200.0,
+        "sum" : 2130400.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1064790.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1064790.5,
+        "min" : 1064790.5,
+        "sum" : 2129581.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1074155.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1074155.0,
+        "min" : 1074155.0,
+        "sum" : 2148310.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1068285.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1068285.0,
+        "min" : 1068285.0,
+        "sum" : 2136570.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061245.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061245.0,
+        "min" : 1061245.0,
+        "sum" : 2122490.0,
+        "standardDeviation" : 0.0
+      } ],
+      "1" : [ {
+        "mean" : 1327673.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1327673.5,
+        "min" : 1327673.5,
+        "sum" : 2655347.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1059595.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1059595.0,
+        "min" : 1059595.0,
+        "sum" : 2119190.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1617672.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1617672.0,
+        "min" : 1617672.0,
+        "sum" : 3235344.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1085155.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1085155.0,
+        "min" : 1085155.0,
+        "sum" : 2170310.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1067060.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1067060.0,
+        "min" : 1067060.0,
+        "sum" : 2134120.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1073025.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1073025.0,
+        "min" : 1073025.0,
+        "sum" : 2146050.0,
+        "standardDeviation" : 0.0
+      } ]
+    }
+  },
+  "vmValuesPredecessor" : {
+    "values" : {
+      "0" : [ {
+        "mean" : 2260309.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2260309.0,
+        "min" : 2260309.0,
+        "sum" : 4520618.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2066785.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2066785.5,
+        "min" : 2066785.5,
+        "sum" : 4133571.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2070559.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2070559.5,
+        "min" : 2070559.5,
+        "sum" : 4141119.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2070320.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2070320.5,
+        "min" : 2070320.5,
+        "sum" : 4140641.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2071440.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2071440.0,
+        "min" : 2071440.0,
+        "sum" : 4142880.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2068505.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2068505.0,
+        "min" : 2068505.0,
+        "sum" : 4137010.0,
+        "standardDeviation" : 0.0
+      } ],
+      "1" : [ {
+        "mean" : 1279819.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1279819.0,
+        "min" : 1279819.0,
+        "sum" : 2559638.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1067380.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1067380.0,
+        "min" : 1067380.0,
+        "sum" : 2134760.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061300.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061300.0,
+        "min" : 1061300.0,
+        "sum" : 2122600.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1060745.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1060745.5,
+        "min" : 1060745.5,
+        "sum" : 2121491.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061325.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061325.0,
+        "min" : 1061325.0,
+        "sum" : 2122650.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1064435.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1064435.0,
+        "min" : 1064435.0,
+        "sum" : 2128870.0,
+        "standardDeviation" : 0.0
+      } ]
+    }
+  },
+  "children" : [ ]
+}];

--- a/a12a0b7f4c162794fca0e7e3fcc6ea3b3a2cbc2b/pure_kopeme/de.dagere.peass.ExampleTest_test(JUNIT_PARAMETERIZED-1).json
+++ b/a12a0b7f4c162794fca0e7e3fcc6ea3b3a2cbc2b/pure_kopeme/de.dagere.peass.ExampleTest_test(JUNIT_PARAMETERIZED-1).json
@@ -1,0 +1,233 @@
+var treeData = {};
+
+var kopemeData = [
+{
+  "call" : "overall",
+  "kiekerPattern" : "public overall.overall()",
+  "otherKiekerPattern" : "public overall.overall()",
+  "name" : null,
+  "key" : "overall.overall_",
+  "otherKey" : "overall.overall_",
+  "parent" : null,
+  "color" : null,
+  "statistic" : {
+    "meanOld" : 1604840.9583333333,
+    "meanCurrent" : 1.0647330645833332E7,
+    "deviationOld" : 581631.1769296796,
+    "deviationCurrent" : 1.0967411885672105E7,
+    "vms" : 4,
+    "callsOld" : 24,
+    "calls" : 24,
+    "tvalue" : -1.6466602513854658
+  },
+  "hasSourceChange" : false,
+  "state" : null,
+  "inVMDeviationPredecessor" : 0.0,
+  "inVMDeviation" : 0.0,
+  "ess" : 0,
+  "vmValues" : {
+    "values" : {
+      "0" : [ {
+        "mean" : 1228489.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1228489.0,
+        "min" : 1228489.0,
+        "sum" : 2456978.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1065200.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1065200.0,
+        "min" : 1065200.0,
+        "sum" : 2130400.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1064790.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1064790.5,
+        "min" : 1064790.5,
+        "sum" : 2129581.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1074155.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1074155.0,
+        "min" : 1074155.0,
+        "sum" : 2148310.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1068285.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1068285.0,
+        "min" : 1068285.0,
+        "sum" : 2136570.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061245.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061245.0,
+        "min" : 1061245.0,
+        "sum" : 2122490.0,
+        "standardDeviation" : 0.0
+      } ],
+      "1" : [ {
+        "mean" : 1327673.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1327673.5,
+        "min" : 1327673.5,
+        "sum" : 2655347.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1059595.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1059595.0,
+        "min" : 1059595.0,
+        "sum" : 2119190.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1617672.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1617672.0,
+        "min" : 1617672.0,
+        "sum" : 3235344.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1085155.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1085155.0,
+        "min" : 1085155.0,
+        "sum" : 2170310.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1067060.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1067060.0,
+        "min" : 1067060.0,
+        "sum" : 2134120.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1073025.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1073025.0,
+        "min" : 1073025.0,
+        "sum" : 2146050.0,
+        "standardDeviation" : 0.0
+      } ]
+    }
+  },
+  "vmValuesPredecessor" : {
+    "values" : {
+      "0" : [ {
+        "mean" : 2260309.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2260309.0,
+        "min" : 2260309.0,
+        "sum" : 4520618.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2066785.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2066785.5,
+        "min" : 2066785.5,
+        "sum" : 4133571.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2070559.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2070559.5,
+        "min" : 2070559.5,
+        "sum" : 4141119.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2070320.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2070320.5,
+        "min" : 2070320.5,
+        "sum" : 4140641.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2071440.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2071440.0,
+        "min" : 2071440.0,
+        "sum" : 4142880.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 2068505.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 2068505.0,
+        "min" : 2068505.0,
+        "sum" : 4137010.0,
+        "standardDeviation" : 0.0
+      } ],
+      "1" : [ {
+        "mean" : 1279819.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1279819.0,
+        "min" : 1279819.0,
+        "sum" : 2559638.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1067380.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1067380.0,
+        "min" : 1067380.0,
+        "sum" : 2134760.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061300.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061300.0,
+        "min" : 1061300.0,
+        "sum" : 2122600.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1060745.5,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1060745.5,
+        "min" : 1060745.5,
+        "sum" : 2121491.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1061325.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1061325.0,
+        "min" : 1061325.0,
+        "sum" : 2122650.0,
+        "standardDeviation" : 0.0
+      }, {
+        "mean" : 1064435.0,
+        "variance" : 0.0,
+        "n" : 2,
+        "max" : 1064435.0,
+        "min" : 1064435.0,
+        "sum" : 2128870.0,
+        "standardDeviation" : 0.0
+      } ]
+    }
+  },
+  "children" : [ ]
+}];

--- a/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
+++ b/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
@@ -92,10 +92,14 @@ public class RTSLogFileVersionReader {
    }
 
    private void addRegularMethodLog(final File viewMethodDir) {
+      boolean runWasSuccessful = checkRunWasSuccessful(viewMethodDir);
+      addMethodLogData(runWasSuccessful, false);
+   }
+
+   private boolean checkRunWasSuccessful(final File viewMethodDir) {
       File viewMethodFile = new File(viewMethodDir, TraceWriter.getShortVersion(version) + TraceFileManager.TXT_ENDING);
       File viewMethodFileZip = new File(viewMethodDir, TraceWriter.getShortVersion(version) + TraceFileManager.ZIP_ENDING);
-      boolean runWasSuccessful = viewMethodFile.exists() || viewMethodFileZip.exists();
-      addMethodLogData(runWasSuccessful, false);
+      return (viewMethodFile.exists() || viewMethodFileZip.exists());
    }
 
    private void addMethodLogData(final boolean runWasSuccessful, final boolean isParameterizedWithoutIndex) {

--- a/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
+++ b/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
@@ -83,7 +83,7 @@ public class RTSLogFileVersionReader {
                   addMethodLogData(true, false);
                } else {
                   test = new TestCase(test.getClazz(), test.getMethod(), test.getModule());
-                  addMethodLogData(false, true);
+                  addMethodLogData(true, true);
                }
             }
          }

--- a/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
+++ b/src/main/java/de/dagere/peass/ci/logs/RTSLogFileVersionReader.java
@@ -60,14 +60,18 @@ public class RTSLogFileVersionReader {
       boolean foundAnyParameterized = false;
 
       if ((!viewMethodDir.exists())) {
-         foundAnyParameterized = addParameterizedMethodLogs(clazzDir);
+         foundAnyParameterized = addParameterizedMethodLogs(clazzDir, null);
       }
+      else {
+         foundAnyParameterized = addParameterizedMethodLogs(clazzDir, viewMethodDir);
+      }
+
       if (!foundAnyParameterized) {
          addRegularMethodLog(viewMethodDir);
       }
    }
 
-   private boolean addParameterizedMethodLogs(final File clazzDir) {
+   private boolean addParameterizedMethodLogs(final File clazzDir, final File viewMethodDir) {
       boolean foundAnyParameterized = false;
       File[] potentialParameterFiles = clazzDir.listFiles();
       if (potentialParameterFiles != null) {
@@ -80,9 +84,15 @@ public class RTSLogFileVersionReader {
                if (methodFile.getName().contains("(")) {
                   String params = fileName.substring(test.getMethod().length() + 1, fileName.length() - 1);
                   test = new TestCase(test.getClazz(), test.getMethod(), test.getModule(), params);
-                  addMethodLogData(true, false);
+                  boolean runWasSuccessful = checkRunWasSuccessful(viewMethodDir);
+                  addMethodLogData(runWasSuccessful, false);
                } else {
                   test = new TestCase(test.getClazz(), test.getMethod(), test.getModule());
+                  /*
+                   * runWasSuccessful is always true in this case
+                   * we can't use checkRunWasSuccessful because no viewMethodDir exists
+                   * if TestCase isParameterizedWithoutIndex
+                   */
                   addMethodLogData(true, true);
                }
             }

--- a/src/main/resources/de/dagere/peass/ci/logs/rts/RTSLogOverviewAction/index.jelly
+++ b/src/main/resources/de/dagere/peass/ci/logs/rts/RTSLogOverviewAction/index.jelly
@@ -59,35 +59,31 @@
               <td>
                 <j:if test='${it.getVmRuns().get(run) != null}'>
                   <a href="../rtsLog_${run.getLinkUsable()}_${it.getVmRuns().get(run).getVersion()}">${it.getVmRuns().get(run).getShortVersion()}</a>
-                  <j:if test="${!it.getVmRuns().get(run).isSuccess() }">
-                    <j:choose>
-                      <j:when test="${it.getVmRuns().get(run).isParameterizedWithoutIndex()}">
-                        <i class="fa fa-exclamation-triangle" title="Regression test selection contains parameterizedTest" style="color: orange"></i>
-                      </j:when>
-                      <j:otherwise>
-                        <i class="fa fa-exclamation-triangle" title="Regression test selection had error" style="color: red"></i>
-                      </j:otherwise>
-                    </j:choose>
 
-                  </j:if>
+                      <j:if test="${it.getVmRuns().get(run).isParameterizedWithoutIndex()}">
+                        <i class="fa fa-exclamation-triangle" title="Regression test selection contains parameterizedTest" style="color: orange"></i>
+                      </j:if>
+
+                      <j:if test="${!it.getVmRuns().get(run).isSuccess() }">
+                        <i class="fa fa-exclamation-triangle" title="Regression test selection had error" style="color: red"></i>
+                      </j:if>
+
                 </j:if>
               </td>
-              <j:if test='${it.getPredecessorVmRuns().get(run) != null}'>
                 <td>
-                  <a href="../rtsLog_${run.getLinkUsable()}_${it.getPredecessorVmRuns().get(run).getVersion()}">${it.getPredecessorVmRuns().get(run).getShortVersion()}</a>
-                  <j:if test="${!it.getPredecessorVmRuns().get(run).isSuccess()}">
-                    <j:choose>
-                      <j:when test="${it.getPredecessorVmRuns().get(run).isParameterizedWithoutIndex()}">
+                  <j:if test='${it.getPredecessorVmRuns().get(run) != null}'>
+                    <a href="../rtsLog_${run.getLinkUsable()}_${it.getPredecessorVmRuns().get(run).getVersion()}">${it.getPredecessorVmRuns().get(run).getShortVersion()}</a>
+
+                      <j:if test="${it.getPredecessorVmRuns().get(run).isParameterizedWithoutIndex()}">
                         <i class="fa fa-exclamation-triangle" title="Regression test selection contains parameterizedTest" style="color: orange"></i>
-                      </j:when>
-                      <j:otherwise>
+                      </j:if>
+
+                      <j:if test="${!it.getPredecessorVmRuns().get(run).isSuccess() }">
                         <i class="fa fa-exclamation-triangle" title="Regression test selection had error" style="color: red"></i>
-                      </j:otherwise>
-                    </j:choose>
+                      </j:if>
 
                   </j:if>
                 </td>
-              </j:if>
             </tr>
           </j:forEach>
         </table>

--- a/src/main/resources/de/dagere/peass/ci/rts/RTSVisualizationAction/index.jelly
+++ b/src/main/resources/de/dagere/peass/ci/rts/RTSVisualizationAction/index.jelly
@@ -90,25 +90,23 @@
           $( "#dialogTraceSelected" ).dialog({ autoOpen: false });
         </script>
 
+        <j:if test="${it.getLogSummary().isVersionContainsParametrizedwhithoutIndex() || it.getLogSummary().isPredecessorContainsParametrizedwhithoutIndex()}">
+          <i class="fa fa-exclamation-triangle" title="Regression test selection contains parameterizedTest" style="color: orange"></i>
+            Info: Regression test selection contains parameterizedTest.
+            <br />
+        </j:if>
+
         <j:if test="${it.getLogSummary().isErrorInCurrentVersionOccured() || it.getLogSummary().isErrorInPredecessorVersionOccured()}">
-           <j:choose>
-               <j:when test="${it.getLogSummary().isVersionContainsParametrizedwhithoutIndex() || it.getLogSummary().isPredecessorContainsParametrizedwhithoutIndex()}">
-                <i class="fa fa-exclamation-triangle" title="Regression test selection contains parameterizedTest" style="color: orange"></i>
-                 Info: Regression test selection contains parameterizedTest.
-                  <br />
-             </j:when>
-             <j:otherwise>
-              <i class="fa fa-exclamation-triangle" title="Regression test selection had error" style="color: red"></i>
-               Warning: An error occured during trace getting execution. Please check the logs for details and consider fixing the configuration or excluding the erroneous test cases.
-                <br />
-              </j:otherwise>
-           </j:choose>
+          <i class="fa fa-exclamation-triangle" title="Regression test selection had error" style="color: red"></i>
+            Warning: An error occured during trace getting execution. Please check the logs for details and consider fixing the configuration or excluding the erroneous test cases.
+            <br />
         </j:if>
         
         <j:forEach var="testcase" items="${it.dynamicSelection}">
           <a href="../rts_${testcase.replace('#', '_')}"> ${testcase} </a>
           <br />
         </j:forEach>
+
       </j:if>
 
       <j:if test="${!it.config.generateTraces}">

--- a/src/test/java/de/peass/ci/logs/TestRTSLogFileReaderParameterized.java
+++ b/src/test/java/de/peass/ci/logs/TestRTSLogFileReaderParameterized.java
@@ -61,6 +61,6 @@ public class TestRTSLogFileReaderParameterized {
       RTSLogData dataImplicitParameterized = rtsVmRunsPredecessor.get(new TestCase("de.dagere.peass.ExampleTest", "test", ""));
       Assert.assertNotNull(dataImplicitParameterized);
       Assert.assertTrue(dataImplicitParameterized.isParameterizedWithoutIndex());
-      Assert.assertFalse(dataImplicitParameterized.isSuccess());
+      Assert.assertTrue(dataImplicitParameterized.isSuccess());
    }
 }


### PR DESCRIPTION
Warning messages for parameterizedTests where handled as errors, causing the buildstate set to "unstable"
(see [issue #146](https://github.com/jenkinsci/peass-ci-plugin/issues/146)).