### PR TITLE
bugfix: when one measurement fails all others are still visualized.

### DIFF
--- a/src/main/java/de/dagere/peass/ci/helper/DefaultMeasurementVisualizer.java
+++ b/src/main/java/de/dagere/peass/ci/helper/DefaultMeasurementVisualizer.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.math3.exception.NumberIsTooSmallException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -75,8 +76,8 @@ public class DefaultMeasurementVisualizer {
 
                final String content = FileUtils.readFileToString(testcaseVisualizationFile, StandardCharsets.UTF_8);
                run.addAction(new MeasurementVisualizationAction(IdHelper.getId(), "measurement_" + name, content));
-            } catch (IOException e) {
-               e.printStackTrace();
+            } catch (IOException | NumberIsTooSmallException e) {
+               LOG.error(e);
             }
          }
       }

--- a/src/main/java/de/dagere/peass/ci/helper/HistogramReader.java
+++ b/src/main/java/de/dagere/peass/ci/helper/HistogramReader.java
@@ -52,13 +52,18 @@ public class HistogramReader {
       // This assumes measurements are only executed once; if this is not the case, the matching result would need to be searched
       final TestMethod testcase = data.getMethods().get(0);
       VMResultChunk chunk = testcase.getDatacollectorResults().get(0).getChunks().get(0);
+      
       String testcaseKey = new TestCase(data).toString();
       
       MeasurementConfig currentConfig = getUpdatedConfiguration(testcaseKey, testcase, chunk);
       
       HistogramValues values = loadResults(chunk, currentConfig);
-        
-      measurements.put(testcaseKey, values);
+      
+      boolean moreThanOneMeasurement = values.getValuesCurrent().length > 1 || values.getValuesBefore().length > 1;
+      
+      if (!moreThanOneMeasurement) {
+         measurements.put(testcaseKey, values);
+      }
    }
 
    private HistogramValues loadResults(final VMResultChunk chunk, final MeasurementConfig currentConfig) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This fixes issue #159
