### PR TITLE
Set GIT_CRYPT_KEY in MeasureVersionBuilder

### DIFF
--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -281,7 +281,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
 
       EnvironmentVariables peassEnv = new EnvironmentVariables(properties);
       for (Map.Entry<String, String> entry : env.entrySet()) {
-         System.out.println("Adding enviroenment: " + entry.getKey() + " " + entry.getValue());
+         System.out.println("Adding environment: " + entry.getKey() + " " + entry.getValue());
          peassEnv.getEnvironmentVariables().put(entry.getKey(), entry.getValue());
       }
 

--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -286,6 +286,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       }
 
       TestSelectionConfig dependencyConfig = new TestSelectionConfig(1, false, true, generateCoverageSelection, writeAsZip);
+      configWithRealGitVersions.getExecutionConfig().setGitCryptKey(peassEnv.getEnvironmentVariables().get("GIT_CRYPT_KEY"));
       PeassProcessConfiguration peassConfig = new PeassProcessConfiguration(updateSnapshotDependencies, configWithRealGitVersions, dependencyConfig,
             peassEnv,
             displayRTSLogs, displayLogs, displayRCALogs, pattern);


### PR DESCRIPTION
GIT_CRYPT_KEY is read from EnvironmentVariables and set in ExecutionConfig.
