### PR TITLE
Fix for Issue #132 (Ignore in current version causes problem)

### DIFF
--- a/src/main/java/de/dagere/peass/ci/process/RTSInfos.java
+++ b/src/main/java/de/dagere/peass/ci/process/RTSInfos.java
@@ -16,10 +16,12 @@ import de.dagere.peass.utils.Constants;
 public class RTSInfos {
    private final boolean staticChanges;
    private final boolean staticallySelectedTests;
+   private final TestSet tests;
 
-   public RTSInfos(final boolean staticChanges, final boolean staticallySelectedTests) {
+   public RTSInfos(final boolean staticChanges, final boolean staticallySelectedTests, TestSet tests) {
       this.staticChanges = staticChanges;
       this.staticallySelectedTests = staticallySelectedTests;
+      this.tests = tests;
    }
 
    public boolean isStaticChanges() {
@@ -30,6 +32,10 @@ public class RTSInfos {
       return staticallySelectedTests;
    }
 
+   public TestSet getTests() {
+      return tests;
+   }
+
    public static RTSInfos readInfosFromFolders(final ResultsFolders results, final PeassProcessConfiguration peassConfig) throws StreamReadException, DatabindException, IOException {
       File staticTestSelectionFile = results.getStaticTestSelectionFile();
       if (staticTestSelectionFile.exists()) {
@@ -37,16 +43,17 @@ public class RTSInfos {
          StaticTestSelection staticTestSelection = Constants.OBJECTMAPPER.readValue(staticTestSelectionFile, StaticTestSelection.class);
          CommitStaticSelection version = staticTestSelection.getCommits().get(peassConfig.getMeasurementConfig().getFixedCommitConfig().getCommit());
          boolean hasStaticallySelectedTests = false;
+         TestSet tests = null;
          if (version != null) {
             if (!version.getChangedClazzes().isEmpty()) {
                staticChanges = true;
             }
-            TestSet tests = version.getTests();
+            tests = version.getTests();
             hasStaticallySelectedTests = !tests.getTests().isEmpty();
          }
-         return new RTSInfos(staticChanges, hasStaticallySelectedTests);
+         return new RTSInfos(staticChanges, hasStaticallySelectedTests, tests);
       } else {
-         return new RTSInfos(false, false);
+         return new RTSInfos(false, false, null);
       }
    }
 }


### PR DESCRIPTION
Fix for error when tests are ignored in current version but not predecessor.

Problem is caused by this combination:
peass creates files (clear & <testname>.txt) even when the test is ignored peass-ci only used the existence of these and other files to determine whether tests should run and did so properly

Fix: peass-ci now checks these against the list of tests to run from the static selection file and removes additional tests

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
