### PR TITLE
Rename goToTag to goToCommit in OneJobImporter also

### DIFF
--- a/src/main/java/de/dagere/peass/ci/peassOverview/importer/OneJobImporter.java
+++ b/src/main/java/de/dagere/peass/ci/peassOverview/importer/OneJobImporter.java
@@ -103,7 +103,7 @@ public class OneJobImporter {
       File fakeMeasurementFolder = new File(fullPeassFolder, "measurement_" + commit + "_" + predecessor);
       fakeMeasurementFolder.mkdir();
 
-      GitUtils.goToTag(commit, workspaceFolder);
+      GitUtils.goToCommit(commit, workspaceFolder);
 
       importRCAData(commit);
       


### PR DESCRIPTION
GitUtils.goToTag was renamed to goToCommit in peass. So peass-ci musst use the new method-name.