### PR TITLE
Some renaming/refactoring of methods in CleanRTSCallable and CleanMeasurementCallable

### DIFF
--- a/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
@@ -66,7 +66,7 @@ public class CleanBuilder extends Builder implements SimpleBuildStep, Serializab
             run.setResult(Result.FAILURE);
             return;
          }
-         CleanMeasurementCallable.cleanFolder(projectName, localWorkspace);
+         CleanMeasurementCallable.cleanFolder(resultsFolders);
       } else {
          listener.getLogger().println("Measurement cleaning disabled");
       }

--- a/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
@@ -15,6 +15,7 @@ import de.dagere.peass.ci.MeasureVersionBuilder;
 import de.dagere.peass.ci.clean.callables.CleanMeasurementCallable;
 import de.dagere.peass.ci.clean.callables.CleanRCACallable;
 import de.dagere.peass.ci.clean.callables.CleanRTSCallable;
+import de.dagere.peass.folders.ResultsFolders;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -46,7 +47,8 @@ public class CleanBuilder extends Builder implements SimpleBuildStep, Serializab
       listener.getLogger().println("Cleaning");
 
       final File localWorkspace = new File(run.getRootDir(), ".." + File.separator + ".." + File.separator + MeasureVersionBuilder.PEASS_FOLDER_NAME).getCanonicalFile();
-      String projectName = new File(workspace.getRemote()).getName();
+      final String projectName = new File(workspace.getRemote()).getName();
+      final ResultsFolders resultsFolders = new ResultsFolders(localWorkspace, projectName);
 
       if (cleanRTS) {
          boolean worked = workspace.act(new CleanRTSCallable(listener));
@@ -54,7 +56,7 @@ public class CleanBuilder extends Builder implements SimpleBuildStep, Serializab
             run.setResult(Result.FAILURE);
             return;
          }
-         CleanRTSCallable.cleanFolder(projectName, localWorkspace);
+         CleanRTSCallable.cleanFolder(resultsFolders);
       } else {
          listener.getLogger().println("Regression Test Selection cleaning disabled");
       }

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
@@ -64,8 +64,6 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
 
-      CleanUtil.cleanProjectFolder(folder, projectName);
-
       deleteCopiedFolders(folder);
    }
 

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
@@ -36,7 +36,7 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
          File folder = new File(potentialSlaveWorkspace.getParentFile(), projectName + PeassFolders.PEASS_FULL_POSTFIX);
          ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
 
-         deleteAllMeasurementData(resultsFolders);
+         cleanFolder(resultsFolders);
 
          return true;
       } catch (IOException e) {
@@ -48,21 +48,19 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
    }
    
    public static void cleanFolder(final ResultsFolders resultsFolders) throws IOException {
-      
-      File trendFile = new File(resultsFolders.getResultFolder(), TrendFileUtil.TREND_FILE_NAME);
-      if (trendFile.exists()) {
-         System.out.println("Deleting " + trendFile);
-         System.out.println("Success: " + trendFile.delete());
-      }
-
-      deleteAllMeasurementData(resultsFolders);
-   }
-
-   private static void deleteAllMeasurementData(final ResultsFolders resultsFolders) throws IOException {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
 
       deleteCopiedFolders(resultsFolders.getResultFolder());
+      deleteTrendFile(resultsFolders);
+   }
+
+   private static void deleteTrendFile(final ResultsFolders resultsFolders) {
+      final File trendFile = new File(resultsFolders.getResultFolder(), TrendFileUtil.TREND_FILE_NAME);
+      if (trendFile.exists()) {
+         System.out.println("Deleting " + trendFile);
+         System.out.println("Success: " + trendFile.delete());
+      }
    }
 
    private static void deleteCopiedFolders(final File folder) throws IOException {

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
@@ -36,7 +36,7 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
          File folder = new File(potentialSlaveWorkspace.getParentFile(), projectName + PeassFolders.PEASS_FULL_POSTFIX);
          ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
 
-         deleteAllMeasurementData(projectName, folder, resultsFolders);
+         deleteAllMeasurementData(resultsFolders);
 
          return true;
       } catch (IOException e) {
@@ -47,24 +47,22 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
       }
    }
    
-   public static void cleanFolder(final String projectName, final File folder) throws IOException {
-      System.out.println("Trying " + folder + " " + projectName);
-      ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
+   public static void cleanFolder(final ResultsFolders resultsFolders) throws IOException {
       
-      File trendFile = new File(folder, TrendFileUtil.TREND_FILE_NAME);
+      File trendFile = new File(resultsFolders.getResultFolder(), TrendFileUtil.TREND_FILE_NAME);
       if (trendFile.exists()) {
          System.out.println("Deleting " + trendFile);
          System.out.println("Success: " + trendFile.delete());
       }
 
-      deleteAllMeasurementData(projectName, folder, resultsFolders);
+      deleteAllMeasurementData(resultsFolders);
    }
 
-   private static void deleteAllMeasurementData(final String projectName, final File folder, final ResultsFolders resultsFolders) throws IOException {
+   private static void deleteAllMeasurementData(final ResultsFolders resultsFolders) throws IOException {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
 
-      deleteCopiedFolders(folder);
+      deleteCopiedFolders(resultsFolders.getResultFolder());
    }
 
    private static void deleteCopiedFolders(final File folder) throws IOException {

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -37,8 +37,6 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
 
          cleanFolder(resultsFolders);
 
-         CleanUtil.cleanProjectFolder(folder, projectName);
-
          return true;
       } catch (IOException e) {
          listener.getLogger().println("Exception thrown");

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -49,10 +49,7 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
       }
    }
    
-   public static void cleanFolder(final String projectName, final File folder) throws IOException {
-      System.out.println("Trying " + folder + " " + projectName);
-      ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
-
+   public static void cleanFolder(final ResultsFolders resultsFolders) throws IOException {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
    }

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -35,8 +35,7 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
          File folder = new File(potentialSlaveWorkspace.getParentFile(), projectName + PeassFolders.PEASS_FULL_POSTFIX);
          ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
 
-         deleteResultFiles(resultsFolders);
-         deleteLogFolders(resultsFolders);
+         cleanFolder(resultsFolders);
 
          CleanUtil.cleanProjectFolder(folder, projectName);
 

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanUtil.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanUtil.java
@@ -12,11 +12,11 @@ public class CleanUtil {
       File projectFolder = new File(folder, projectName);
       if (projectFolder.exists()) {
          try {
-            PeassFolders folders = new PeassFolders(projectFolder);
-            FileUtils.deleteDirectory(folders.getProjectFolder());
-            if (folders.getPeassFolder().exists()) {
-               System.out.println("Deleting " + folders.getPeassFolder().getAbsolutePath());
-               FileUtils.deleteDirectory(folders.getPeassFolder());
+            PeassFolders peassFolders = new PeassFolders(projectFolder);
+            FileUtils.deleteDirectory(peassFolders.getProjectFolder());
+            if (peassFolders.getPeassFolder().exists()) {
+               System.out.println("Deleting " + peassFolders.getPeassFolder().getAbsolutePath());
+               FileUtils.deleteDirectory(peassFolders.getPeassFolder());
             }
          } catch (RuntimeException e) {
             System.err.println("For some reason, folder was already cleaned partially; consider fully cleaning manually");


### PR DESCRIPTION
- alignment of CleanRTSCallable and CleanMeasurementCallable
- passing ResultFolders from CleanBuilder
- don't call CleanUtils.cleanProjectFolder if you just wanna clean rts- or measurement-data
