### PR TITLE
Don't clean whole folder if only RTS- or measurement-data should be c…

### DIFF
--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanMeasurementCallable.java
@@ -64,8 +64,6 @@ public class CleanMeasurementCallable implements FileCallable<Boolean> {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
 
-      CleanUtil.cleanProjectFolder(folder, projectName);
-
       deleteCopiedFolders(folder);
    }
 

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -38,8 +38,6 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
          deleteResultFiles(resultsFolders);
          deleteLogFolders(resultsFolders);
 
-         CleanUtil.cleanProjectFolder(folder, projectName);
-
          return true;
       } catch (IOException e) {
          listener.getLogger().println("Exception thrown");


### PR DESCRIPTION
If RTS- or measurement-data is cleaned, CleanUtil.cleanProjectFolder should not be called since this deletes the whole projectFolder.