### PR TITLE
Refactored CleanRTSCallable

### DIFF
--- a/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/clean/CleanBuilder.java
@@ -15,6 +15,7 @@ import de.dagere.peass.ci.MeasureVersionBuilder;
 import de.dagere.peass.ci.clean.callables.CleanMeasurementCallable;
 import de.dagere.peass.ci.clean.callables.CleanRCACallable;
 import de.dagere.peass.ci.clean.callables.CleanRTSCallable;
+import de.dagere.peass.folders.ResultsFolders;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -46,7 +47,8 @@ public class CleanBuilder extends Builder implements SimpleBuildStep, Serializab
       listener.getLogger().println("Cleaning");
 
       final File localWorkspace = new File(run.getRootDir(), ".." + File.separator + ".." + File.separator + MeasureVersionBuilder.PEASS_FOLDER_NAME).getCanonicalFile();
-      String projectName = new File(workspace.getRemote()).getName();
+      final String projectName = new File(workspace.getRemote()).getName();
+      final ResultsFolders resultsFolders = new ResultsFolders(localWorkspace, projectName);
 
       if (cleanRTS) {
          boolean worked = workspace.act(new CleanRTSCallable(listener));
@@ -54,7 +56,7 @@ public class CleanBuilder extends Builder implements SimpleBuildStep, Serializab
             run.setResult(Result.FAILURE);
             return;
          }
-         CleanRTSCallable.cleanFolder(projectName, localWorkspace);
+         CleanRTSCallable.cleanFolder(resultsFolders);
       } else {
          listener.getLogger().println("Regression Test Selection cleaning disabled");
       }

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -49,10 +49,7 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
       }
    }
    
-   public static void cleanFolder(final String projectName, final File folder) throws IOException {
-      System.out.println("Trying " + folder + " " + projectName);
-      ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
-
+   public static void cleanFolder(final ResultsFolders resultsFolders) throws IOException {
       deleteResultFiles(resultsFolders);
       deleteLogFolders(resultsFolders);
    }

--- a/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
+++ b/src/main/java/de/dagere/peass/ci/clean/callables/CleanRTSCallable.java
@@ -35,8 +35,7 @@ public class CleanRTSCallable implements FileCallable<Boolean> {
          File folder = new File(potentialSlaveWorkspace.getParentFile(), projectName + PeassFolders.PEASS_FULL_POSTFIX);
          ResultsFolders resultsFolders = new ResultsFolders(folder, projectName);
 
-         deleteResultFiles(resultsFolders);
-         deleteLogFolders(resultsFolders);
+         cleanFolder(resultsFolders);
 
          CleanUtil.cleanProjectFolder(folder, projectName);
 


### PR DESCRIPTION

- ResultsFolders are now created in CleanBuilder and passed to CleanRTSCallable.
- use already existing method cleanFolder to deleteResultFiles and deleteLogFolders