### PR TITLE
Make cleanGoal configurable

### DIFF
--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -151,6 +151,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
    private boolean failOnRtsError = false;
 
    private String excludeForTracing = "";
+   private String cleanGoal = "cleanTest";
 
    @DataBoundConstructor
    public MeasureVersionBuilder() {
@@ -345,6 +346,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       listener.getLogger().println("Create default constructor: " + createDefaultConstructor);
       listener.getLogger().println("Fail on error in RTS: " + failOnRtsError);
       listener.getLogger().println("Redirect subprocess output to file: " + redirectSubprocessOutputToFile);
+      listener.getLogger().println("CleanGoal: " + cleanGoal);
    }
 
    private String getJobName(final Run<?, ?> run) {
@@ -366,6 +368,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       config.setEarlyStop(false);
       config.getExecutionConfig().setShowStart(showStart);
       config.setDirectlyMeasureKieker(directlyMeasureKieker);
+      config.getExecutionConfig().setCleanGoal(cleanGoal);
 
       if (executeParallel) {
          System.out.println("Measuring parallel");
@@ -428,6 +431,10 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
 
       executionConfig.setTestTransformer(testTransformer);
       executionConfig.setTestExecutor(testExecutor);
+
+      if (cleanGoal != null && !"".equals(cleanGoal)) {
+         executionConfig.setCleanGoal(cleanGoal);
+      }
 
       if (clazzFolders != null && !"".equals(clazzFolders.trim())) {
          List<String> pathes = ExecutionConfig.buildFolderList(clazzFolders);
@@ -715,6 +722,15 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
    @DataBoundSetter
    public void setTestGoal(final String testGoal) {
       this.testGoal = testGoal;
+   }
+
+   public String getCleanGoal() {
+      return cleanGoal;
+   }
+
+   @DataBoundSetter
+   public void setCleanGoal(final String cleanGoal) {
+      this.cleanGoal = cleanGoal;
    }
 
    public String getPl() {

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.jelly
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.jelly
@@ -125,6 +125,13 @@
           </f:entry>
         </td>
       </tr>
+      <tr>
+        <td>
+          <f:entry title="${%cleanGoal}" field="cleanGoal" description="${%cleanGoalDescr}">
+            <f:textbox default="cleanTest" />
+          </f:entry>
+        </td>
+      </tr>
     </table>
 
     <h1>${%VersionSelection}</h1>

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.properties
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config.properties
@@ -45,6 +45,9 @@ propertiesDescr=Defines the properties that should be passed to the build proces
 testGoal=Test Goal / Task
 testGoalDescr=Test goal (maven) / task (gradle) that should be used for executing tests (default 'test')
 
+cleanGoal=Clean Goal
+cleanGoalDescr=Clean goal (maven) / task (gradle) that should be used for clean up generated Klass from the previous build (default 'CleanTest')
+
 pl=Project List
 plDescr=List of maven modules, that should be built, in the notion that mvn --pl used
 

--- a/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config_de.properties
+++ b/src/main/resources/de/dagere/peass/ci/MeasureVersionBuilder/config_de.properties
@@ -45,6 +45,10 @@ propertiesDescr=Definiert die Properties, die an die Buildprozesse übergeben wer
 testGoal=Test Goal / Task
 testGoalDescr=Test-Goal (maven) / Task (gradle) das für die Ausführung von Tests aufgerufen werden soll (default 'test')
 
+cleanGoal=Clean Goal
+cleanGoalDescr=Clean goal (maven) / task (gradle) das für die Reinigung der generierte Klasse aus dem vorherigen Build verwenden soll (default 'CleanTest')
+
+
 pl=Projektliste
 plDescr=Liste der Maven-Module, die gebaut werden sollen, in der üblichen Maven Notation die --pl übergeben wird
 


### PR DESCRIPTION
The paramater cleanGoal was not in peass-ci configurable.
This fix make it available in peass-ci.

