### PR TITLE
Delete directory before copying, so error that occurs with Jenkins agents on some setups is avoided

### DIFF
--- a/src/main/java/de/dagere/peass/ci/process/LocalPeassProcessManager.java
+++ b/src/main/java/de/dagere/peass/ci/process/LocalPeassProcessManager.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -127,6 +128,12 @@ public class LocalPeassProcessManager {
       listener.getLogger().println(Arrays.toString(new RuntimeException().getStackTrace()));
       listener.getLogger().println("Remote Peass path: " + remotePeassPath);
       FilePath remotePeassFolder = new FilePath(workspace.getChannel(), remotePeassPath);
+
+      FileUtils.deleteDirectory(localWorkspace);
+      if (!localWorkspace.mkdirs()) {
+         listener.getLogger().println("Could not re-create " + localWorkspace);
+      }
+      
       DirScanner.Glob dirScanner = new DirScanner.Glob("**/*,**/.git/**", "", false);
       int count = remotePeassFolder.copyRecursiveTo(dirScanner, new FilePath(localWorkspace), "Copy including git folder");
       listener.getLogger().println("Copied " + count + " files from " + remotePeassFolder + " to " + localWorkspace.getAbsolutePath());


### PR DESCRIPTION
This is a rebase of the branch 'debugCopyFromRemote' that was created for us after contact by mail.

We rebased the branch to test the changes on the latest release of the plugin, to make sure they worked the same as on the version it was originally branched from.

The branch fixes problems we had when the plugin is copying its data from the remote agent back to the controller, which includes the GIT repository that has several files configured as read-only. After the initial copying, this part of the code would throw exceptions when trying to overwrite these files on the controller.

We did try to make the copying work in other ways (eg exclude the repo), but this then had other negative effects on the code, so we decided to stick with the original change.