### PR TITLE
Set buildstate unstable if json-file is not found in RCAVisualizer

### DIFF
--- a/src/main/java/de/dagere/peass/ci/rca/RCAVisualizer.java
+++ b/src/main/java/de/dagere/peass/ci/rca/RCAVisualizer.java
@@ -101,7 +101,8 @@ public class RCAVisualizer {
                metadata.copyFiles(commitVisualizationFolder);
                createRCAAction(longestPrefix, testcases, change, metadata);
             } else {
-               LOG.error("An error occured: {} not found", jsFile.getAbsolutePath());
+               run.setResult(Result.UNSTABLE);
+               LOG.error("An error occured: {} not found. Set buildstate to unstable.", jsFile.getAbsolutePath());
             }
          }
       }


### PR DESCRIPTION
I'm not sure how to handle this. If this is an error, shouldn't buildstate be unstable? If it's not a hard error, message should maybe just be a warning?
