### PR TITLE
Some changes of setting/handling failures

### DIFF
--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -289,9 +289,10 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
    }
 
    private void measure(final Run<?, ?> run, final LocalPeassProcessManager processManager, final Set<TestMethodCall> tests) throws IOException, InterruptedException {
-      boolean worked = processManager.measure(tests);
-      if (!worked) {
-         run.setResult(Result.FAILURE);
+      final boolean measureWorked = processManager.measure(tests);
+      if (!measureWorked) {
+         //We don't want the whole build to fail, if measurements for single tests failed, so it's just UNSTABLE
+         run.setResult(Result.UNSTABLE);
          return;
       }
 
@@ -299,10 +300,11 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
 
       if (executeRCA) {
          final CauseSearcherConfig causeSearcherConfig = generateCauseSearchConfig();
-         boolean rcaWorked = processManager.rca(changes, causeSearcherConfig);
+         final boolean rcaWorked = processManager.rca(changes, causeSearcherConfig);
          processManager.visualizeRCAResults(run, changes);
          if (!rcaWorked) {
-            run.setResult(Result.FAILURE);
+            //We don't want the whole build to fail, if rca for single tests failed, so it's just UNSTABLE
+            run.setResult(Result.UNSTABLE);
          }
       }
    }

--- a/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
+++ b/src/main/java/de/dagere/peass/ci/MeasureVersionBuilder.java
@@ -282,7 +282,7 @@ public class MeasureVersionBuilder extends Builder implements SimpleBuildStep, S
       }
       if (!missingMeasurements.isEmpty()) {
          listener.getLogger().println("Did not succeed with all measurements, marking as unstable. Missing: " + missingMeasurements);
-         if (run.getResult() == null || Result.FAILURE.equals(run.getResult())) {
+         if (run.getResult() == null) {
             run.setResult(Result.UNSTABLE);
          }
       }

--- a/src/main/java/de/dagere/peass/ci/logs/measurement/MeasurementActionCreator.java
+++ b/src/main/java/de/dagere/peass/ci/logs/measurement/MeasurementActionCreator.java
@@ -1,5 +1,6 @@
 package de.dagere.peass.ci.logs.measurement;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -67,12 +68,20 @@ public class MeasurementActionCreator {
          TestCase testcase = entry.getKey();
          int vmId = 0;
          for (LogFiles files : entry.getValue()) {
-            String logData = processConfig.getFileText(files.getCurrent());
-            run.addAction(new LogAction(IdHelper.getId(), testcase, vmId, measurementConfig.getFixedCommitConfig().getCommit(), logData));
-            String logDataOld = processConfig.getFileText(files.getPredecessor());
-            run.addAction(new LogAction(IdHelper.getId(), testcase, vmId, measurementConfig.getFixedCommitConfig().getCommitOld(), logDataOld));
+            addLogAction(run, testcase, vmId, measurementConfig.getFixedCommitConfig().getCommit(), files.getCurrent());
+            addLogAction(run, testcase, vmId, measurementConfig.getFixedCommitConfig().getCommitOld(), files.getPredecessor());
             vmId++;
          }
       }
    }
+
+   private void addLogAction(final Run<?, ?> run, TestCase testcase, int vmId, String commit, File logfile) throws IOException {
+      if (logfile.exists()) {
+         String logData = processConfig.getFileText(logfile);
+         run.addAction(new LogAction(IdHelper.getId(), testcase, vmId, commit, logData));
+      } else {
+         LOG.error("No Logfile could be found for {} and commit {}", testcase, commit);
+      }
+   }
+
 }


### PR DESCRIPTION

- You can't overwrite result FAILURE with UNSTABLE (see https://javadoc.jenkins-ci.org/hudson/model/Run.html#setResult(hudson.model.Result))
- Build should not completely fail if single tests have errors in measure or rca
- If measure-log of single test is missing, you get an error-message, no exception